### PR TITLE
Change How The Webhook Source Connectors Are Registered

### DIFF
--- a/src/Krimson.Connectors/Http/HostingExtensions.cs
+++ b/src/Krimson.Connectors/Http/HostingExtensions.cs
@@ -29,7 +29,7 @@ public static class ServicesExtensions {
             .FromAssemblyOf<T>()
             .AddClasses(classes => classes.AssignableTo<WebhookSourceConnector>())
             .UsingRegistrationStrategy(RegistrationStrategy.Skip)
-            .AsSelfWithInterfaces()
+            .As<WebhookSourceConnector>()
             .WithSingletonLifetime()
         );
 


### PR DESCRIPTION
## Updated

Updated the Krimson.Connectors/Http/HostingExtensions to use `.As<WebhookSourceConnector>()` instead of `.AsSelfWithInterfaces()`.

## Reason
The webhook endpoint was not mapped in the `HostingExtensions.UseKrimsonWebhooks()` method as the `app.Services.GetServices<WebhookSourceConnector>()` call was not returning any webhook connectors, causing the endpoint to 404.