### PR TITLE
Fix DI wireup

### DIFF
--- a/src/Krimson.Core/Components/Processors/KrimsonSubscriptionGapTracker.cs
+++ b/src/Krimson.Core/Components/Processors/KrimsonSubscriptionGapTracker.cs
@@ -4,8 +4,13 @@ using System.Collections.Concurrent;
 namespace Krimson.Processors;
 
 static class KrimsonGapCheckServicesExtensions {
-    public static IServiceCollection AddKrimsonSubscriptionGapTracker(this IServiceCollection services) =>
-        services.AddSingleton<IKrimsonSubscriptionGapTracker>(new KrimsonSubscriptionGapTracker());
+    public static IServiceCollection AddKrimsonSubscriptionGapTracker(this IServiceCollection services) {
+        services.AddSingleton<KrimsonSubscriptionGapTracker>();
+        services.AddSingleton<IKrimsonSubscriptionGapTracker>(sp => sp.GetRequiredService<KrimsonSubscriptionGapTracker>());
+
+        return services;
+    }
+
 }
 
 public interface IKrimsonSubscriptionGapTracker {


### PR DESCRIPTION
Both interface and implementation need to be available from DI as Krimson loads the implementation and user code loads the interface