### PR TITLE
Add resilience to schema registry calls

### DIFF
--- a/src/Krimson.Core/Components/SchemaRegistry/Configuration/KrimsonSchemaRegistryBuilder.cs
+++ b/src/Krimson.Core/Components/SchemaRegistry/Configuration/KrimsonSchemaRegistryBuilder.cs
@@ -17,12 +17,13 @@ public record KrimsonSchemaRegistryBuilder {
         return this with { Options = options };
     }
 
-    public KrimsonSchemaRegistryBuilder Connection(string url, string apiKey, string apiSecret) {
+    public KrimsonSchemaRegistryBuilder Connection(string url, string apiKey, string apiSecret, int requestTimeoutMs) {
         return OverrideConfig(
             cfg => {
                 cfg.Url                        = url;
                 cfg.BasicAuthUserInfo          = $"{apiKey}:{apiSecret}";
                 cfg.BasicAuthCredentialsSource = AuthCredentialsSource.UserInfo;
+                cfg.RequestTimeoutMs           = requestTimeoutMs;
             }
         );
     }
@@ -33,7 +34,8 @@ public record KrimsonSchemaRegistryBuilder {
         return Connection(
             configuration.GetValue("Krimson:SchemaRegistry:Url", Options.RegistryConfiguration.Url)!,
             configuration.GetValue("Krimson:SchemaRegistry:ApiKey", "")!,
-            configuration.GetValue("Krimson:SchemaRegistry:ApiSecret", "")!
+            configuration.GetValue("Krimson:SchemaRegistry:ApiSecret", "")!,
+            configuration.GetValue<int>("Krimson:SchemaRegistry:RequestTimeout", Options.RegistryConfiguration.RequestTimeoutMs.Value)!
         );
     }
 

--- a/src/Krimson.Core/Configuration/DefaultConfigs.cs
+++ b/src/Krimson.Core/Configuration/DefaultConfigs.cs
@@ -52,5 +52,6 @@ public static class DefaultConfigs {
         new() {
             Url                        = "localhost:8081",               // ready for docker
             BasicAuthCredentialsSource = AuthCredentialsSource.UserInfo, // default
+            RequestTimeoutMs = 500,
         };
 }

--- a/src/Krimson.Core/Hosting/KrimsonBuilder.cs
+++ b/src/Krimson.Core/Hosting/KrimsonBuilder.cs
@@ -23,8 +23,8 @@ public class KrimsonBuilder {
     public   IServiceCollection Services { get; }
     internal string?            ClientId { get; }
 
-    public KrimsonBuilder AddSchemaRegistry(string url, string apiKey = "", string apiSecret = "") {
-        Services.AddKrimsonSchemaRegistry((_, builder) => builder.Connection(url, apiKey, apiSecret));
+    public KrimsonBuilder AddSchemaRegistry(string url, string apiKey = "", string apiSecret = "", int requestTimeoutMs = 500) {
+        Services.AddKrimsonSchemaRegistry((_, builder) => builder.Connection(url, apiKey, apiSecret, requestTimeoutMs));
         return this;
     }
 

--- a/src/Krimson.Serializers.ConfluentProtobuf/Krimson.Serializers.ConfluentProtobuf.csproj
+++ b/src/Krimson.Serializers.ConfluentProtobuf/Krimson.Serializers.ConfluentProtobuf.csproj
@@ -2,6 +2,7 @@
   <ItemGroup>
     <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="2.0.2" />
     <PackageReference Include="Google.Protobuf" Version="3.22.1" />
+    <PackageReference Include="Polly" Version="7.2.3" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Krimson.Serializers.ConfluentProtobuf/ProtobufDynamicSerializer.cs
+++ b/src/Krimson.Serializers.ConfluentProtobuf/ProtobufDynamicSerializer.cs
@@ -40,7 +40,7 @@ public class ProtobufDynamicSerializer : IDynamicSerializer {
     ISchemaRegistryClient               RegistryClient       { get; }
     Func<Type, dynamic>                 GetSerializer        { get; }
     ConcurrentDictionary<Type, dynamic> Serializers          { get; }
-    AsyncRetryPolicy<byte[]>                    SerializeRetryPolicy { get; }
+    AsyncRetryPolicy<byte[]>            SerializeRetryPolicy { get; }
 
     public async Task<byte[]> SerializeAsync(object? data, SerializationContext context) {
         if (data is null)


### PR DESCRIPTION
- Reduce schema registry timeout to 500ms from 30 seconds
- Introduce a retry mechanism for serialize/deserialize calls: 3 failures before exploding